### PR TITLE
feat: update to ACVM 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510b65efd4d20bf266185ce0a5dc7d29bcdd196a6a1835c20908fd88040de76c"
+checksum = "084577e67b44c72d1cdfabe286d48adac6f5e0ad441ef134c5c467f4b6eee291"
 dependencies = [
  "acir_field",
  "flate2",
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f032e710c67fd146caedc8fe1dea6e95f01ab59453e42d59b604a51fef3dfe"
+checksum = "a267ef529f4b132293199ecdf8c232ade817f01d916039f2d34562cab39e75e9"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2611266039740ffd1978f23258bd6ce3166c22cf15b8227685c2f3bb20ae2ee0"
+checksum = "4e1d6795105b50b13fa0dd1779b5191c4d8e9cd98b357b0b9a0b04a847baacf0"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -43,6 +43,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "sha2",
+ "sha3",
  "thiserror",
 ]
 
@@ -67,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ec51160c66eba75dc15a028a2391675386fd395b3897478d89a386c64a48dd"
+checksum = "3131af53d17ac12340c0ff50f8555d8e040321f8078b8ee3cd8846560b6a44a9"
 dependencies = [
  "acir",
 ]
@@ -251,8 +252,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "build-data"
@@ -629,8 +637,8 @@ dependencies = [
 
 [[package]]
 name = "iter-extended"
-version = "0.5.1"
-source = "git+https://github.com/noir-lang/noir?rev=7f6dede414c46790545b1994713d1976c5623711#7f6dede414c46790545b1994713d1976c5623711"
+version = "0.6.0"
+source = "git+https://github.com/noir-lang/noir?rev=0181813203a9e3e46c6d8c3169ad5d25971d4282#0181813203a9e3e46c6d8c3169ad5d25971d4282"
 
 [[package]]
 name = "itertools"
@@ -666,6 +674,15 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -709,12 +726,13 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "0.5.1"
-source = "git+https://github.com/noir-lang/noir?rev=7f6dede414c46790545b1994713d1976c5623711#7f6dede414c46790545b1994713d1976c5623711"
+version = "0.6.0"
+source = "git+https://github.com/noir-lang/noir?rev=0181813203a9e3e46c6d8c3169ad5d25971d4282#0181813203a9e3e46c6d8c3169ad5d25971d4282"
 dependencies = [
  "acvm",
  "iter-extended",
  "serde",
+ "serde_json",
  "thiserror",
  "toml",
 ]
@@ -996,6 +1014,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest 0.9.0",
+ "keccak",
  "opaque-debug",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ rust-version = "1.66"
 crate-type = ["cdylib"]
 
 [dependencies]
-acvm = "0.10.3"
-iter-extended = { git = "https://github.com/noir-lang/noir", rev = "7f6dede414c46790545b1994713d1976c5623711"}
-noirc_abi = { git = "https://github.com/noir-lang/noir", rev = "7f6dede414c46790545b1994713d1976c5623711"}
+acvm = "0.11.0"
+iter-extended = { git = "https://github.com/noir-lang/noir", rev = "0181813203a9e3e46c6d8c3169ad5d25971d4282"}
+noirc_abi = { git = "https://github.com/noir-lang/noir", rev = "0181813203a9e3e46c6d8c3169ad5d25971d4282"}
 wasm-bindgen = { version = "0.2.85", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.34"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
This PR updates us to use ACVM 0.11.0 to match the 0.6.0 release of Nargo.