### PR TITLE
feat: use JS naming convention for generated functions

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -12,7 +12,7 @@ use crate::js_transforms::{js_map_to_witness_map, witness_map_to_js_map};
 
 use self::temp::{input_value_from_json_type, JsonTypes};
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = abiEncode)]
 pub fn abi_encode(
     abi: JsValue,
     inputs: JsValue,
@@ -55,7 +55,7 @@ pub fn abi_encode(
     Ok(witness_map_to_js_map(witness_map))
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = abiDecode)]
 pub fn abi_decode(abi: JsValue, witness_map: js_sys::Map) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
     let abi: Abi = JsValueSerdeExt::into_serde(&abi).map_err(|err| err.to_string())?;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -53,7 +53,7 @@ impl PartialWitnessGenerator for SimulatedBackend {
     }
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = executeCircuit)]
 pub async fn execute_circuit(
     circuit: Vec<u8>,
     initial_witness: js_sys::Map,

--- a/test/browser/abi_encode.test.ts
+++ b/test/browser/abi_encode.test.ts
@@ -1,4 +1,4 @@
-import initACVMSimulator, { abi_encode, abi_decode } from "../../pkg/";
+import initACVMSimulator, { abiEncode, abiDecode } from "../../pkg/";
 
 test("recovers original inputs when abi encoding and decoding", async () => {
   await initACVMSimulator();
@@ -21,10 +21,10 @@ test("recovers original inputs when abi encoding and decoding", async () => {
     foo: "1",
     bar: ["1", "2"],
   };
-  const initial_witness: Map<string, string> = abi_encode(abi, inputs, null);
+  const initial_witness: Map<string, string> = abiEncode(abi, inputs, null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const decoded_inputs: { inputs: Record<string, any>; return_value: any } =
-    abi_decode(abi, initial_witness);
+    abiDecode(abi, initial_witness);
 
   expect(BigInt(decoded_inputs.inputs.foo)).toBe(BigInt(inputs.foo));
   expect(BigInt(decoded_inputs.inputs.bar[0])).toBe(BigInt(inputs.bar[0]));

--- a/test/browser/execute_circuit.test.ts
+++ b/test/browser/execute_circuit.test.ts
@@ -1,7 +1,7 @@
 import initACVMSimulator, {
-  abi_encode,
-  abi_decode,
-  execute_circuit,
+  abiEncode,
+  abiDecode,
+  executeCircuit,
 } from "../../pkg/";
 
 test("successfully executes circuit and extracts return value", async () => {
@@ -59,8 +59,8 @@ test("successfully executes circuit and extracts return value", async () => {
   };
   const return_witness: number = abi.return_witnesses[0];
 
-  const initial_witness: Map<number, string> = abi_encode(abi, inputs, null);
-  const solved_witness: Map<number, string> = await execute_circuit(
+  const initial_witness: Map<number, string> = abiEncode(abi, inputs, null);
+  const solved_witness: Map<number, string> = await executeCircuit(
     bytecode,
     initial_witness,
     () => {
@@ -75,7 +75,7 @@ test("successfully executes circuit and extracts return value", async () => {
   // Solved witness should contain expected return value
   expect(BigInt(solved_witness.get(return_witness) as string)).toBe(3n);
 
-  const decoded_inputs = abi_decode(abi, solved_witness);
+  const decoded_inputs = abiDecode(abi, solved_witness);
 
   expect(BigInt(decoded_inputs.return_value)).toBe(3n);
 });
@@ -138,7 +138,7 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
-  const solved_witness: Map<number, string> = await execute_circuit(
+  const solved_witness: Map<number, string> = await executeCircuit(
     oracle_bytecode,
     initial_witness,
     async (_name: string, _inputs: string[]) => {

--- a/test/node/abi_encode.test.ts
+++ b/test/node/abi_encode.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { abi_encode, abi_decode } from "../../pkg/";
+import { abiEncode, abiDecode } from "../../pkg/";
 
 test("recovers original inputs when abi encoding and decoding", () => {
   // TODO use ts-rs to get ABI type bindings.
@@ -20,10 +20,10 @@ test("recovers original inputs when abi encoding and decoding", () => {
     foo: "1",
     bar: ["1", "2"],
   };
-  const initial_witness: Map<string, string> = abi_encode(abi, inputs, null);
+  const initial_witness: Map<string, string> = abiEncode(abi, inputs, null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const decoded_inputs: { inputs: Record<string, any>; return_value: any } =
-    abi_decode(abi, initial_witness);
+    abiDecode(abi, initial_witness);
 
   expect(BigInt(decoded_inputs.inputs.foo)).toBe(BigInt(inputs.foo));
   expect(BigInt(decoded_inputs.inputs.bar[0])).toBe(BigInt(inputs.bar[0]));

--- a/test/node/execute_circuit.test.ts
+++ b/test/node/execute_circuit.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { abi_encode, abi_decode, execute_circuit } from "../../pkg/";
+import { abiEncode, abiDecode, executeCircuit } from "../../pkg/";
 
 test("successfully executes circuit and extracts return value", async () => {
   // Noir program which enforces that x != y and returns x + y.
@@ -54,8 +54,8 @@ test("successfully executes circuit and extracts return value", async () => {
   };
   const return_witness: number = abi.return_witnesses[0];
 
-  const initial_witness: Map<number, string> = abi_encode(abi, inputs, null);
-  const solved_witness: Map<number, string> = await execute_circuit(
+  const initial_witness: Map<number, string> = abiEncode(abi, inputs, null);
+  const solved_witness: Map<number, string> = await executeCircuit(
     bytecode,
     initial_witness,
     () => {
@@ -70,7 +70,7 @@ test("successfully executes circuit and extracts return value", async () => {
   // Solved witness should contain expected return value
   expect(BigInt(solved_witness.get(return_witness) as string)).toBe(3n);
 
-  const decoded_inputs = abi_decode(abi, solved_witness);
+  const decoded_inputs = abiDecode(abi, solved_witness);
 
   expect(BigInt(decoded_inputs.return_value)).toBe(3n);
 });
@@ -131,7 +131,7 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
-  const solved_witness: Map<number, string> = await execute_circuit(
+  const solved_witness: Map<number, string> = await executeCircuit(
     oracle_bytecode,
     initial_witness,
     async (_name: string, _inputs: string[]) => {


### PR DESCRIPTION
This PR adds the [`js-name` attribute](https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-rust-exports/js_name.html) to the exported functions so they are in camelCase rather than snake_case.