### PR TITLE
chore: enforce type on oracle callback function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ pub fn build_info() -> JsValue {
 const TS_APPEND_CONTENT: &'static str = r#"
 // Map from witness index to hex string value of witness.
 export type WitnessMap = Map<number, string>;
-
 "#;
 
 // WitnessMap
@@ -60,66 +59,9 @@ extern "C" {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type JsWitnessMap;
 
-    /// The `clear()` method removes all elements from a Map object.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear)
-    #[wasm_bindgen(method, js_class = "Map")]
-    pub fn clear(this: &JsWitnessMap);
-
-    /// The `delete()` method removes the specified element from a Map object.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete)
-    #[wasm_bindgen(method, js_class = "Map")]
-    pub fn delete(this: &JsWitnessMap, key: &JsValue) -> bool;
-
-    /// The `forEach()` method executes a provided function once per each
-    /// key/value pair in the Map object, in insertion order.
-    /// Note that in Javascript land the `Key` and `Value` are reversed compared to normal expectations:
-    /// # Examples
-    /// ```
-    /// let js_map = Map::new();
-    /// js_map.for_each(&mut |value, key| {
-    ///     // Do something here...
-    /// })
-    /// ```
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach)
-    #[wasm_bindgen(method, js_class = "Map", js_name = forEach)]
-    pub fn for_each(this: &JsWitnessMap, callback: &mut dyn FnMut(JsValue, JsValue));
-
-    /// The `get()` method returns a specified element from a Map object.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get)
-    #[wasm_bindgen(method, js_class = "Map")]
-    pub fn get(this: &JsWitnessMap, key: &JsValue) -> JsValue;
-
-    /// The `has()` method returns a boolean indicating whether an element with
-    /// the specified key exists or not.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has)
-    #[wasm_bindgen(method, js_class = "Map")]
-    pub fn has(this: &JsWitnessMap, key: &JsValue) -> bool;
-
-    /// The Map object holds key-value pairs. Any value (both objects and
-    /// primitive values) maybe used as either a key or a value.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
     #[wasm_bindgen(constructor, js_class = "Map")]
     pub fn new() -> JsWitnessMap;
 
-    /// The `set()` method adds or updates an element with a specified key
-    /// and value to a Map object.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set)
-    #[wasm_bindgen(method, js_class = "Map")]
-    pub fn set(this: &JsWitnessMap, key: &JsValue, value: &JsValue) -> Map;
-
-    /// The value of size is an integer representing how many entries
-    /// the Map object has. A set accessor function for size is undefined;
-    /// you can not change this property.
-    ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size)
-    #[wasm_bindgen(method, js_class = "Map", getter, structural)]
-    pub fn size(this: &JsWitnessMap) -> u32;
 }
 
 impl Default for JsWitnessMap {

--- a/test/browser/execute_circuit.test.ts
+++ b/test/browser/execute_circuit.test.ts
@@ -140,14 +140,16 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
+  let observedName = "";
+  let observedInputs: string[] = [];
   const oracleCallback: OracleCallback = async (
-    _name: string,
-    _inputs: string[]
+    name: string,
+    inputs: string[]
   ) => {
-    // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
-    // the values for `name` and `inputs` are correct, we can `console.log` them however.
-    // console.log(name)
-    // console.log(inputs)
+    // Throwing inside the oracle callback causes a timeout so we log the observed values
+    // and defer the check against expected values until after the execution is complete.
+    observedName = name;
+    observedInputs = inputs;
 
     // Witness(1) + Witness(2) = 1 + 1 = 2
     return ["0x02"];
@@ -157,6 +159,13 @@ test("successfully processes oracle opcodes", async () => {
     initial_witness,
     oracleCallback
   );
+
+  // Check that expected values were passed to oracle callback.
+  expect(observedName).toBe("example_oracle");
+  expect(observedInputs).toStrictEqual([
+    initial_witness.get(1) as string,
+    initial_witness.get(2) as string,
+  ]);
 
   // If incorrect value is written into circuit then execution should halt due to unsatisfied constraint in
   // arithmetic opcode. Nevertheless, check that returned value was inserted correctly.

--- a/test/browser/execute_circuit.test.ts
+++ b/test/browser/execute_circuit.test.ts
@@ -3,6 +3,7 @@ import initACVMSimulator, {
   abiDecode,
   executeCircuit,
   WitnessMap,
+  OracleCallback,
 } from "../../pkg/";
 
 test("successfully executes circuit and extracts return value", async () => {
@@ -139,18 +140,22 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
+  const oracleCallback: OracleCallback = async (
+    _name: string,
+    _inputs: string[]
+  ) => {
+    // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
+    // the values for `name` and `inputs` are correct, we can `console.log` them however.
+    // console.log(name)
+    // console.log(inputs)
+
+    // Witness(1) + Witness(2) = 1 + 1 = 2
+    return ["0x02"];
+  };
   const solved_witness: WitnessMap = await executeCircuit(
     oracle_bytecode,
     initial_witness,
-    async (_name: string, _inputs: string[]) => {
-      // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
-      // the values for `name` and `inputs` are correct, we can `console.log` them however.
-      // console.log(name)
-      // console.log(inputs)
-
-      // Witness(1) + Witness(2) = 1 + 1 = 2
-      return ["0x02"];
-    }
+    oracleCallback
   );
 
   // If incorrect value is written into circuit then execution should halt due to unsatisfied constraint in

--- a/test/node/execute_circuit.test.ts
+++ b/test/node/execute_circuit.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@jest/globals";
-import { abiEncode, abiDecode, executeCircuit, WitnessMap } from "../../pkg/";
+import {
+  abiEncode,
+  abiDecode,
+  executeCircuit,
+  WitnessMap,
+  OracleCallback,
+} from "../../pkg/";
 
 test("successfully executes circuit and extracts return value", async () => {
   // Noir program which enforces that x != y and returns x + y.
@@ -131,18 +137,22 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
+  const oracleCallback: OracleCallback = async (
+    _name: string,
+    _inputs: string[]
+  ) => {
+    // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
+    // the values for `name` and `inputs` are correct, we can `console.log` them however.
+    // console.log(name)
+    // console.log(inputs)
+
+    // Witness(1) + Witness(2) = 1 + 1 = 2
+    return ["0x02"];
+  };
   const solved_witness: WitnessMap = await executeCircuit(
     oracle_bytecode,
     initial_witness,
-    async (_name: string, _inputs: string[]) => {
-      // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
-      // the values for `name` and `inputs` are correct, we can `console.log` them however.
-      // console.log(name)
-      // console.log(inputs)
-
-      // Witness(1) + Witness(2) = 1 + 1 = 2
-      return ["0x02"];
-    }
+    oracleCallback
   );
 
   // If incorrect value is written into circuit then execution should halt due to unsatisfied constraint in

--- a/test/node/execute_circuit.test.ts
+++ b/test/node/execute_circuit.test.ts
@@ -137,14 +137,16 @@ test("successfully processes oracle opcodes", async () => {
     "0x0000000000000000000000000000000000000000000000000000000000000001"
   );
 
+  let observedName = "";
+  let observedInputs: string[] = [];
   const oracleCallback: OracleCallback = async (
-    _name: string,
-    _inputs: string[]
+    name: string,
+    inputs: string[]
   ) => {
-    // We cannot use jest matchers here (or write to a variable in the outside scope) so cannot test that
-    // the values for `name` and `inputs` are correct, we can `console.log` them however.
-    // console.log(name)
-    // console.log(inputs)
+    // Throwing inside the oracle callback causes a timeout so we log the observed values
+    // and defer the check against expected values until after the execution is complete.
+    observedName = name;
+    observedInputs = inputs;
 
     // Witness(1) + Witness(2) = 1 + 1 = 2
     return ["0x02"];
@@ -154,6 +156,13 @@ test("successfully processes oracle opcodes", async () => {
     initial_witness,
     oracleCallback
   );
+
+  // Check that expected values were passed to oracle callback.
+  expect(observedName).toBe("example_oracle");
+  expect(observedInputs).toStrictEqual([
+    initial_witness.get(1) as string,
+    initial_witness.get(2) as string,
+  ]);
 
   // If incorrect value is written into circuit then execution should halt due to unsatisfied constraint in
   // arithmetic opcode. Nevertheless, check that returned value was inserted correctly.


### PR DESCRIPTION
# Related issue(s)

Related to #8 

# Description

## Summary of changes

This PR enforces that any oracle callback passed to `execute_circuit` must satisfy the type `(name: string, inputs: string[]) => Promise<string[]>`

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
