### PR TITLE
chore: refactor foreign call logic into separate module

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -184,6 +184,7 @@ pub async fn execute_circuit(
     Ok(witness_map.into())
 }
 
+/// Peforms the foreign calls associated with [`unresolved_oracle_calls`][OracleData] and writes the results to [`witness_map`][WitnessMap].
 async fn process_oracle_calls(
     witness_map: &mut WitnessMap,
     oracle_callback: &OracleCallback,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -18,7 +18,7 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::{
     barretenberg::{pedersen::Pedersen, scalar_mul::ScalarMul, schnorr::SchnorrSig, Barretenberg},
-    js_transforms::{field_element_to_js_string, js_value_to_field_element},
+    foreign_calls::{resolve_oracle, OracleCallback},
     JsWitnessMap,
 };
 
@@ -139,24 +139,6 @@ impl PartialWitnessGenerator for SimulatedBackend {
     }
 }
 
-#[wasm_bindgen(typescript_custom_section)]
-const ORACLE_CALLBACK: &'static str = r#"
-/**
- * A callback which performs an oracle call and returns the response as an array of outputs.
- * @callback OracleCallback
- * @param {string} name - The identifier for the type of oracle call being performed.
- * @param {string[]} inputs - An array of hex encoded inputs to the oracle call.
- * @returns {Promise<string[]>} outputs - An array of hex encoded outputs containing the results of the oracle call.
- */
-export type OracleCallback = (name: string, inputs: string[]) => Promise<string[]>;
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(extends = js_sys::Function, typescript_type = "OracleCallback")]
-    pub type OracleCallback;
-}
-
 /// Executes an ACIR circuit to generate the solved witness from the initial witness.
 ///
 /// @param {Uint8Array} circuit - A serialized representation of an ACIR circuit
@@ -188,24 +170,10 @@ pub async fn execute_circuit(
                 unsolved_opcodes,
                 unresolved_brillig_calls: _,
             } => {
-                // Perform all oracle queries
-                let oracle_call_futures: Vec<_> = required_oracle_data
-                    .into_iter()
-                    .map(|oracle_call| resolve_oracle(&oracle_callback, oracle_call))
-                    .collect();
+                process_oracle_calls(&mut witness_map, &oracle_callback, required_oracle_data)
+                    .await?;
 
-                // Insert results into the witness map
-                for oracle_call_future in oracle_call_futures {
-                    let resolved_oracle_call: OracleData = oracle_call_future.await.unwrap();
-                    for (i, witness_index) in resolved_oracle_call.outputs.iter().enumerate() {
-                        insert_value(
-                            witness_index,
-                            resolved_oracle_call.output_values[i],
-                            &mut witness_map,
-                        )
-                        .map_err(|err| err.to_string())?;
-                    }
-                }
+                // TODO: add handling for `Brillig` opcodes.
 
                 // Use new opcodes as returned by ACVM.
                 opcodes = unsolved_opcodes;
@@ -214,6 +182,29 @@ pub async fn execute_circuit(
     }
 
     Ok(witness_map.into())
+}
+
+async fn process_oracle_calls(
+    witness_map: &mut WitnessMap,
+    oracle_callback: &OracleCallback,
+    unresolved_oracle_calls: Vec<OracleData>,
+) -> Result<(), String> {
+    // Perform all oracle queries
+    let oracle_call_futures: Vec<_> = unresolved_oracle_calls
+        .into_iter()
+        .map(|oracle_call| resolve_oracle(&oracle_callback, oracle_call))
+        .collect();
+
+    // Insert results into the witness map
+    for oracle_call_future in oracle_call_futures {
+        let resolved_oracle_call: OracleData = oracle_call_future.await.unwrap();
+        for (i, witness_index) in resolved_oracle_call.outputs.iter().enumerate() {
+            insert_value(witness_index, resolved_oracle_call.output_values[i], witness_map)
+                .map_err(|err| err.to_string())?;
+        }
+    }
+
+    Ok(())
 }
 
 fn insert_value(
@@ -233,61 +224,4 @@ fn insert_value(
     }
 
     Ok(())
-}
-
-async fn resolve_oracle(
-    oracle_callback: &OracleCallback,
-    mut unresolved_oracle_call: OracleData,
-) -> Result<OracleData, String> {
-    // Prepare to call
-    let name = JsValue::from(unresolved_oracle_call.name.clone());
-    assert_eq!(unresolved_oracle_call.inputs.len(), unresolved_oracle_call.input_values.len());
-    let inputs = js_sys::Array::default();
-    for input_value in &unresolved_oracle_call.input_values {
-        let hex_js_string = field_element_to_js_string(input_value);
-        inputs.push(&hex_js_string);
-    }
-
-    // Call and await
-    let this = JsValue::null();
-    let ret_js_val = oracle_callback
-        .call2(&this, &name, &inputs)
-        .map_err(|err| format!("Error calling oracle_resolver: {}", format_js_err(err)))?;
-    let ret_js_prom: js_sys::Promise = ret_js_val.into();
-    let ret_future: wasm_bindgen_futures::JsFuture = ret_js_prom.into();
-    let js_resolution = ret_future
-        .await
-        .map_err(|err| format!("Error awaiting oracle_resolver: {}", format_js_err(err)))?;
-
-    // Check that result conforms to expected shape.
-    if !js_resolution.is_array() {
-        return Err("oracle_resolver must return a Promise<string[]>".into());
-    }
-    let js_arr = js_sys::Array::from(&js_resolution);
-    let output_len = js_arr.length() as usize;
-    let expected_output_len = unresolved_oracle_call.outputs.len();
-    if output_len != expected_output_len {
-        return Err(format!(
-            "Expected output from oracle '{}' of {} elements, but instead received {}",
-            unresolved_oracle_call.name, expected_output_len, output_len
-        ));
-    }
-
-    // Insert result into oracle data.
-    for elem in js_arr.iter() {
-        if !elem.is_string() {
-            return Err("Non-string element in oracle_resolver return".into());
-        }
-        unresolved_oracle_call.output_values.push(js_value_to_field_element(elem)?)
-    }
-    let resolved_oracle_call = unresolved_oracle_call;
-
-    Ok(resolved_oracle_call)
-}
-
-fn format_js_err(err: JsValue) -> String {
-    match err.as_string() {
-        Some(str) => str,
-        None => "Unknown".to_owned(),
-    }
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -184,7 +184,7 @@ pub async fn execute_circuit(
     Ok(witness_map.into())
 }
 
-/// Peforms the foreign calls associated with [`unresolved_oracle_calls`][OracleData] and writes the results to [`witness_map`][WitnessMap].
+/// Performs the foreign calls associated with [`unresolved_oracle_calls`][OracleData] and writes the results to [`witness_map`][WitnessMap].
 async fn process_oracle_calls(
     witness_map: &mut WitnessMap,
     oracle_callback: &OracleCallback,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -193,7 +193,7 @@ async fn process_oracle_calls(
     // Perform all oracle queries
     let oracle_call_futures: Vec<_> = unresolved_oracle_calls
         .into_iter()
-        .map(|oracle_call| resolve_oracle(&oracle_callback, oracle_call))
+        .map(|oracle_call| resolve_oracle(oracle_callback, oracle_call))
         .collect();
 
     // Insert results into the witness map

--- a/src/foreign_calls.rs
+++ b/src/foreign_calls.rs
@@ -1,0 +1,102 @@
+use acvm::{acir::circuit::opcodes::OracleData, FieldElement};
+
+use js_sys::JsString;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+
+use crate::js_transforms::{js_value_to_field_element, field_element_to_js_string};
+
+#[wasm_bindgen(typescript_custom_section)]
+const ORACLE_CALLBACK: &'static str = r#"
+/**
+* A callback which performs an oracle call and returns the response as an array of outputs.
+* @callback OracleCallback
+* @param {string} name - The identifier for the type of oracle call being performed.
+* @param {string[]} inputs - An array of hex encoded inputs to the oracle call.
+* @returns {Promise<string[]>} outputs - An array of hex encoded outputs containing the results of the oracle call.
+*/
+export type OracleCallback = (name: string, inputs: string[]) => Promise<string[]>;
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = js_sys::Function, typescript_type = "OracleCallback")]
+    pub type OracleCallback;
+}
+
+pub(super) async fn resolve_oracle(
+    oracle_callback: &OracleCallback,
+    mut unresolved_oracle_call: OracleData,
+) -> Result<OracleData, String> {
+    // Prepare to call
+    let (name, inputs) = prepare_oracle_args(&unresolved_oracle_call);
+
+    // Perform foreign call
+    let outputs = perform_foreign_call(oracle_callback, name, inputs).await?;
+
+    // Insert result into oracle data.
+    unresolved_oracle_call.output_values = outputs;
+    let outputs_len = unresolved_oracle_call.outputs.len();
+    let output_values_len = unresolved_oracle_call.output_values.len();
+    if outputs_len != output_values_len {
+        return Err(format!(
+            "Expected output from oracle '{}' of {} elements, but instead received {}",
+            unresolved_oracle_call.name, outputs_len, output_values_len
+        ));
+    }
+
+    Ok(unresolved_oracle_call)
+}
+
+fn prepare_oracle_args(unresolved_oracle_call: &OracleData) -> (JsString, js_sys::Array) {
+    let name = JsString::from(unresolved_oracle_call.name.clone());
+
+    let inputs = js_sys::Array::default();
+    for input_value in &unresolved_oracle_call.input_values {
+        let hex_js_string = field_element_to_js_string(input_value);
+        inputs.push(&hex_js_string);
+    }
+
+    assert_eq!(unresolved_oracle_call.inputs.len(), unresolved_oracle_call.input_values.len());
+
+    (name, inputs)
+}
+
+async fn perform_foreign_call(
+    foreign_call_callback: &OracleCallback,
+    name: JsString,
+    inputs: js_sys::Array,
+) -> Result<Vec<FieldElement>, String> {
+    // Call and await
+    let this = JsValue::null();
+    let ret_js_val = foreign_call_callback
+        .call2(&this, &name, &inputs)
+        .map_err(|err| format!("Error calling `foreign_call_callback`: {}", format_js_err(err)))?;
+    let ret_js_prom: js_sys::Promise = ret_js_val.into();
+    let ret_future: wasm_bindgen_futures::JsFuture = ret_js_prom.into();
+    let js_resolution = ret_future
+        .await
+        .map_err(|err| format!("Error awaiting `foreign_call_callback`: {}", format_js_err(err)))?;
+
+    // Check that result conforms to expected shape.
+    if !js_resolution.is_array() {
+        return Err("`foreign_call_callback` must return a Promise<string[]>".into());
+    }
+    let js_arr = js_sys::Array::from(&js_resolution);
+
+    let mut outputs = Vec::with_capacity(js_arr.length() as usize);
+    for elem in js_arr.iter() {
+        if !elem.is_string() {
+            return Err("Non-string element in oracle_resolver return".into());
+        }
+        outputs.push(js_value_to_field_element(elem)?)
+    }
+
+    Ok(outputs)
+}
+
+fn format_js_err(err: JsValue) -> String {
+    match err.as_string() {
+        Some(str) => str,
+        None => "Unknown".to_owned(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::prelude::*;
 mod abi;
 mod barretenberg;
 mod execute;
+mod foreign_calls;
 mod js_transforms;
 mod public_witness;
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

## Summary\*

#27 requires us to handle foreign calls for both oracle and brillig opcodes. This PR refactors this code away from the main execution loop and splits it up so that we can reuse code for brillig opcodes.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
