### PR TITLE
chore: remove double printing of install location

### DIFF
--- a/installPhase.sh
+++ b/installPhase.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -v out ]; then
-  echo "Will install package to $out (defined outside installPhase.sh script)"
-else
-  out="./result"
-  echo "Will install package to $out"
-fi
-
 mkdir -p $out
 cp README.md $out/
 cp -r ./pkg/* $out/


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I've removed a double-print of the same info

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
