### PR TITLE
chore: enforce type checks on logging and build info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "acvm",
  "build-data",
  "console_error_panic_hook",
+ "const-str",
  "getrandom",
  "gloo-utils",
  "iter-extended",
@@ -467,6 +468,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "const-str"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5cd0d05ad8032f6252503d4a61401b640ce9365082accf046c68c7a419339d"
 
 [[package]]
 name = "core-foundation-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ wasm-logger = "0.2.0"
 console_error_panic_hook = "0.1.7"
 gloo-utils = { version = "0.1", features = ["serde"] }
 js-sys = "0.3.62"
+const-str = "0.5.5"
 
 # Barretenberg WASM dependencies
 thiserror = "1.0.21"

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -8,7 +8,7 @@ const LOG_LEVEL: &'static str = r#"
 * @typedef {Object} BuildInfo - Information about how the installed package was built
 * @property {string} gitHash - The hash of the git commit from which the package was built. 
 * @property {string} version - The version of the package at the built git commit.
-* @property {string} dirty - Whether the package contained uncommitted changes when built.
+* @property {boolean} dirty - Whether the package contained uncommitted changes when built.
  */
 export type BuildInfo = {
   gitHash: string;

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -9,7 +9,7 @@ const LOG_LEVEL: &'static str = r#"
 * @typedef {Object} BuildInfo - Information about how the installed package was built
 * @property {string} gitHash - The hash of the git commit from which the package was built. 
 * @property {string} version - The version of the package at the built git commit.
-* @property {string} dirty - A string representation of whether the package contained uncommited changes when built.
+* @property {string} dirty - Whether the package contained uncommited changes when built.
  */
 export type BuildInfo = {
   gitHash: string;
@@ -26,15 +26,16 @@ extern "C" {
 
 #[derive(Serialize, Deserialize)]
 struct BuildInfo {
+    #[serde(rename = "gitHash")]
     git_hash: &'static str,
     version: &'static str,
-    dirty: &'static str,
+    dirty: bool,
 }
 
 const BUILD_INFO: BuildInfo = BuildInfo {
     git_hash: env!("GIT_COMMIT"),
     version: env!("CARGO_PKG_VERSION"),
-    dirty: env!("GIT_DIRTY"),
+    dirty: const_str::equal!(env!("GIT_DIRTY"), "true"),
 };
 
 /// Returns the `BuildInfo` object containing information about how the installed package was built.

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -8,7 +8,7 @@ const LOG_LEVEL: &'static str = r#"
 * @typedef {Object} BuildInfo - Information about how the installed package was built
 * @property {string} gitHash - The hash of the git commit from which the package was built. 
 * @property {string} version - The version of the package at the built git commit.
-* @property {string} dirty - Whether the package contained uncommited changes when built.
+* @property {string} dirty - Whether the package contained uncommitted changes when built.
  */
 export type BuildInfo = {
   gitHash: string;

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -5,7 +5,6 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(typescript_custom_section)]
 const LOG_LEVEL: &'static str = r#"
 /**
- * A callback which performs an foreign call and returns the response.
 * @typedef {Object} BuildInfo - Information about how the installed package was built
 * @property {string} gitHash - The hash of the git commit from which the package was built. 
 * @property {string} version - The version of the package at the built git commit.

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,46 @@
+use gloo_utils::format::JsValueSerdeExt;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const LOG_LEVEL: &'static str = r#"
+/**
+ * A callback which performs an foreign call and returns the response.
+* @typedef {Object} BuildInfo - Information about how the installed package was built
+* @property {string} gitHash - The hash of the git commit from which the package was built. 
+* @property {string} version - The version of the package at the built git commit.
+* @property {string} dirty - A string representation of whether the package contained uncommited changes when built.
+ */
+export type BuildInfo = {
+  gitHash: string;
+  version: string;
+  dirty: string;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "BuildInfo")]
+    pub type JsBuildInfo;
+}
+
+#[derive(Serialize, Deserialize)]
+struct BuildInfo {
+    git_hash: &'static str,
+    version: &'static str,
+    dirty: &'static str,
+}
+
+const BUILD_INFO: BuildInfo = BuildInfo {
+    git_hash: env!("GIT_COMMIT"),
+    version: env!("CARGO_PKG_VERSION"),
+    dirty: env!("GIT_DIRTY"),
+};
+
+/// Returns the `BuildInfo` object containing information about how the installed package was built.
+/// @returns {BuildInfo} - Information on how the installed package was built.
+#[wasm_bindgen(js_name = buildInfo, skip_jsdoc)]
+pub fn build_info() -> JsBuildInfo {
+    console_error_panic_hook::set_once();
+    <JsValue as JsValueSerdeExt>::from_serde(&BUILD_INFO).unwrap().into()
+}

--- a/src/foreign_calls.rs
+++ b/src/foreign_calls.rs
@@ -3,7 +3,7 @@ use acvm::FieldElement;
 use js_sys::JsString;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
-use crate::js_transforms::js_value_to_field_element;
+use crate::js_witness_map::js_value_to_field_element;
 
 #[wasm_bindgen(typescript_custom_section)]
 const FOREIGN_CALL_HANDLER: &'static str = r#"

--- a/src/js_witness_map.rs
+++ b/src/js_witness_map.rs
@@ -2,10 +2,32 @@ use acvm::{
     acir::native_types::{Witness, WitnessMap},
     FieldElement,
 };
-use js_sys::JsString;
-use wasm_bindgen::JsValue;
+use js_sys::{JsString, Map};
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
-use crate::JsWitnessMap;
+#[wasm_bindgen(typescript_custom_section)]
+const WITNESS_MAP: &'static str = r#"
+// Map from witness index to hex string value of witness.
+export type WitnessMap = Map<number, string>;
+"#;
+
+// WitnessMap
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = Map, js_name = "WitnessMap", typescript_type = "WitnessMap")]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub type JsWitnessMap;
+
+    #[wasm_bindgen(constructor, js_class = "Map")]
+    pub fn new() -> JsWitnessMap;
+
+}
+
+impl Default for JsWitnessMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl From<WitnessMap> for JsWitnessMap {
     fn from(witness_map: WitnessMap) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![warn(unreachable_pub)]
 
 use gloo_utils::format::JsValueSerdeExt;
-use js_sys::Map;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -11,13 +10,14 @@ mod barretenberg;
 mod compression;
 mod execute;
 mod foreign_calls;
-mod js_transforms;
+mod js_witness_map;
 mod logging;
 mod public_witness;
 
 pub use abi::{abi_decode, abi_encode};
 pub use compression::{compress_witness, decompress_witness};
 pub use execute::execute_circuit;
+pub use js_witness_map::JsWitnessMap;
 pub use logging::{init_log_level, LogLevel};
 pub use public_witness::{get_public_parameters_witness, get_public_witness, get_return_witness};
 
@@ -38,28 +38,4 @@ const BUILD_INFO: BuildInfo = BuildInfo {
 pub fn build_info() -> JsValue {
     console_error_panic_hook::set_once();
     <JsValue as JsValueSerdeExt>::from_serde(&BUILD_INFO).unwrap()
-}
-
-#[wasm_bindgen(typescript_custom_section)]
-const WITNESS_MAP: &'static str = r#"
-// Map from witness index to hex string value of witness.
-export type WitnessMap = Map<number, string>;
-"#;
-
-// WitnessMap
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(extends = Map, js_name = "WitnessMap", typescript_type = "WitnessMap")]
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub type JsWitnessMap;
-
-    #[wasm_bindgen(constructor, js_class = "Map")]
-    pub fn new() -> JsWitnessMap;
-
-}
-
-impl Default for JsWitnessMap {
-    fn default() -> Self {
-        Self::new()
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,9 @@
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
 
-use gloo_utils::format::JsValueSerdeExt;
-use serde::{Deserialize, Serialize};
-use wasm_bindgen::prelude::*;
-
 mod abi;
 mod barretenberg;
+mod build_info;
 mod compression;
 mod execute;
 mod foreign_calls;
@@ -15,27 +12,9 @@ mod logging;
 mod public_witness;
 
 pub use abi::{abi_decode, abi_encode};
+pub use build_info::build_info;
 pub use compression::{compress_witness, decompress_witness};
 pub use execute::execute_circuit;
 pub use js_witness_map::JsWitnessMap;
 pub use logging::{init_log_level, LogLevel};
 pub use public_witness::{get_public_parameters_witness, get_public_witness, get_return_witness};
-
-#[derive(Serialize, Deserialize)]
-pub struct BuildInfo {
-    git_hash: &'static str,
-    version: &'static str,
-    dirty: &'static str,
-}
-
-const BUILD_INFO: BuildInfo = BuildInfo {
-    git_hash: env!("GIT_COMMIT"),
-    version: env!("CARGO_PKG_VERSION"),
-    dirty: env!("GIT_DIRTY"),
-};
-
-#[wasm_bindgen(js_name = buildInfo)]
-pub fn build_info() -> JsValue {
-    console_error_panic_hook::set_once();
-    <JsValue as JsValueSerdeExt>::from_serde(&BUILD_INFO).unwrap()
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,7 @@
 
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Map;
-use log::Level;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 mod abi;
@@ -14,11 +12,13 @@ mod compression;
 mod execute;
 mod foreign_calls;
 mod js_transforms;
+mod logging;
 mod public_witness;
 
 pub use abi::{abi_decode, abi_encode};
 pub use compression::{compress_witness, decompress_witness};
 pub use execute::execute_circuit;
+pub use logging::{init_log_level, LogLevel};
 pub use public_witness::{get_public_parameters_witness, get_public_witness, get_return_witness};
 
 #[derive(Serialize, Deserialize)]
@@ -26,18 +26,6 @@ pub struct BuildInfo {
     git_hash: &'static str,
     version: &'static str,
     dirty: &'static str,
-}
-
-#[wasm_bindgen]
-pub fn init_log_level(level: String) {
-    // Set the static variable from Rust
-    use std::sync::Once;
-
-    let log_level = Level::from_str(&level).unwrap_or(Level::Error);
-    static SET_HOOK: Once = Once::new();
-    SET_HOOK.call_once(|| {
-        wasm_logger::init(wasm_logger::Config::new(log_level));
-    });
 }
 
 const BUILD_INFO: BuildInfo = BuildInfo {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,28 @@
+use js_sys::JsString;
+use log::Level;
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const LOG_LEVEL: &'static str = r#"
+export type LogLevel = "OFF" | "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE";
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = JsString, typescript_type = "LogLevel")]
+    pub type LogLevel;
+}
+
+#[wasm_bindgen]
+pub fn init_log_level(level: LogLevel) {
+    // Set the static variable from Rust
+    use std::sync::Once;
+
+    let log_level = level.as_string().unwrap();
+    let log_level = Level::from_str(&log_level).unwrap_or(Level::Error);
+    static SET_HOOK: Once = Once::new();
+    SET_HOOK.call_once(|| {
+        wasm_logger::init(wasm_logger::Config::new(log_level));
+    });
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,7 +14,7 @@ extern "C" {
     pub type LogLevel;
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = initLogLevel)]
 pub fn init_log_level(level: LogLevel) {
     // Set the static variable from Rust
     use std::sync::Once;

--- a/test/browser/execute_circuit.test.ts
+++ b/test/browser/execute_circuit.test.ts
@@ -4,13 +4,13 @@ import initACVMSimulator, {
   abiDecode,
   executeCircuit,
   WitnessMap,
-  init_log_level,
+  initLogLevel,
 } from "../../result/";
 
 beforeEach(async () => {
   await initACVMSimulator();
 
-  init_log_level("INFO");
+  initLogLevel("INFO");
 });
 
 it("successfully executes circuit and extracts return value", async () => {

--- a/test/node/build_info.test.ts
+++ b/test/node/build_info.test.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
-import { buildInfo } from "../../result/";
+import { BuildInfo, buildInfo } from "../../result/";
 import child_process from "child_process";
 import pkg from "../../package.json";
 
 it("returns the correct build into", () => {
-  const info = buildInfo();
+  const info: BuildInfo = buildInfo();
 
   // TODO: enforce that `package.json` and `Cargo.toml` are consistent.
   expect(info.version).to.be.eq(pkg.version);
@@ -13,5 +13,5 @@ it("returns the correct build into", () => {
     .execSync("git rev-parse HEAD")
     .toString()
     .trim();
-  expect(info.git_hash).to.be.eq(revision);
+  expect(info.gitHash).to.be.eq(revision);
 });


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves #8 

## Summary\*

This PR adds proper type information for the inputs/return values for logging and build info functions. I've also changed it so the git dirtiness flag is now a boolean.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
