### PR TITLE
feat: allow calling pedersen opcode with non-zero domain separator

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683909802,
-        "narHash": "sha256-2CL8NYKLYwwy6n0RyldvH86ULgrSvfzHrgq2Qf0ZUkE=",
+        "lastModified": 1686952051,
+        "narHash": "sha256-mpsCXzHMaqSveQcD/SA9k3NH4pF167KqR5/oYJJjKE8=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "97c9bc72aebab850b4a647d6e6cc50085226eafb",
+        "rev": "65e651d04c6092cb5ca079cd9e12ed9b5846fa3a",
         "type": "github"
       },
       "original": {

--- a/src/barretenberg/mod.rs
+++ b/src/barretenberg/mod.rs
@@ -102,6 +102,12 @@ mod wasm {
         }
     }
 
+    impl From<u32> for WASMValue {
+        fn from(value: u32) -> Self {
+            WASMValue(Some(Value::I32(value as i32)))
+        }
+    }
+
     impl From<i32> for WASMValue {
         fn from(value: i32) -> Self {
             WASMValue(Some(Value::I32(value)))

--- a/src/barretenberg/mod.rs
+++ b/src/barretenberg/mod.rs
@@ -247,7 +247,7 @@ mod wasm {
         debug!("> Will Load black box functions vendor binary");
         let mut store = Store::default();
 
-        let mem_type = MemoryType::new(22, None, false);
+        let mem_type = MemoryType::new(23, None, false);
         let memory = Memory::new(&mut store, mem_type).unwrap();
 
         let function_env = FunctionEnv::new(&mut store, memory.clone());

--- a/src/barretenberg/pedersen.rs
+++ b/src/barretenberg/pedersen.rs
@@ -3,16 +3,27 @@ use acvm::FieldElement;
 use super::{Assignments, Barretenberg, Error, FIELD_BYTES};
 
 pub(crate) trait Pedersen {
-    fn encrypt(&self, inputs: Vec<FieldElement>) -> Result<(FieldElement, FieldElement), Error>;
+    fn encrypt(
+        &self,
+        inputs: Vec<FieldElement>,
+        hash_index: u32,
+    ) -> Result<(FieldElement, FieldElement), Error>;
 }
 
 impl Pedersen for Barretenberg {
-    fn encrypt(&self, inputs: Vec<FieldElement>) -> Result<(FieldElement, FieldElement), Error> {
+    fn encrypt(
+        &self,
+        inputs: Vec<FieldElement>,
+        hash_index: u32,
+    ) -> Result<(FieldElement, FieldElement), Error> {
         let input_buf = Assignments::from(inputs).to_bytes();
         let input_ptr = self.allocate(&input_buf)?;
         let result_ptr: usize = 0;
 
-        self.call_multiple("pedersen_plookup_commit", vec![&input_ptr, &result_ptr.into()])?;
+        self.call_multiple(
+            "pedersen_plookup_commit_with_hash_index",
+            vec![&input_ptr, &result_ptr.into(), &hash_index.into()],
+        )?;
 
         let result_bytes: [u8; 2 * FIELD_BYTES] = self.read_memory(result_ptr);
         let (point_x_bytes, point_y_bytes) = result_bytes.split_at(FIELD_BYTES);

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -105,17 +105,20 @@ impl PartialWitnessGenerator for SimulatedBackend {
         &self,
         initial_witness: &mut WitnessMap,
         inputs: &[FunctionInput],
-        // Assumed to be `0`
-        _domain_separator: u32,
+        domain_separator: u32,
         outputs: &[Witness],
     ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         let scalars: Result<Vec<_>, _> =
             inputs.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
         let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
 
-        let (res_x, res_y) = self.blackbox_vendor.encrypt(scalars).map_err(|err| {
-            OpcodeResolutionError::BlackBoxFunctionFailed(BlackBoxFunc::Pedersen, err.to_string())
-        })?;
+        let (res_x, res_y) =
+            self.blackbox_vendor.encrypt(scalars, domain_separator).map_err(|err| {
+                OpcodeResolutionError::BlackBoxFunctionFailed(
+                    BlackBoxFunc::Pedersen,
+                    err.to_string(),
+                )
+            })?;
         insert_value(&outputs[0], res_x, initial_witness)?;
         insert_value(&outputs[1], res_y, initial_witness)?;
         Ok(OpcodeResolution::Solved)


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps the barretenberg commit to match that used by `noir-lang/noir` so that we can pass a custom domain separator to the pedersen opcode.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
