### PR TITLE
chore: rename `acvm-simulator` to `acvm_js`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,16 +55,16 @@ jobs:
           git commit -m 'chore: Update lockfile'
           git push
 
-  dispatch-acvm-simulator-wasm:
-    name: Dispatch to acvm-simulator-wasm
+  dispatch-acvm-js-wasm:
+    name: Dispatch to acvm-js-wasm
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to acvm-simulator-wasm
+      - name: Dispatch to acvm-js-wasm
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: update.yml
-          repo: noir-lang/acvm-simulator-wasm
+          repo: noir-lang/acvm-js-wasm
           token: ${{ secrets.ACVM_SIMULATOR_RELEASES_TOKEN }}
-          inputs: '{ "acvm-simulator-ref": "${{ needs.release-please.outputs.tag-name }}" }'
+          inputs: '{ "acvm-js-ref": "${{ needs.release-please.outputs.tag-name }}" }'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-acvm-simulator:
+  build-acvm-js:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -24,7 +24,7 @@ jobs:
           name: barretenberg
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Build acvm-simulator
+      - name: Build acvm-js
         run: |
           nix build .#
 
@@ -34,12 +34,12 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: acvm-simulator
+          name: acvm-js
           path: ${{ env.UPLOAD_PATH }}
           retention-days: 3
 
   test-node:
-    needs: [build-acvm-simulator]
+    needs: [build-acvm-js]
     name: Node.js Tests
     runs-on: ubuntu-latest
 
@@ -50,7 +50,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: acvm-simulator
+          name: acvm-js
           path: ./result
 
       - name: Set up test environment
@@ -60,7 +60,7 @@ jobs:
         run: yarn test
 
   test-browser:
-    needs: [build-acvm-simulator]
+    needs: [build-acvm-js]
     name: Browser Tests
     runs-on: ubuntu-latest
 
@@ -71,7 +71,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: acvm-simulator
+          name: acvm-js
           path: ./result
 
       - name: Set up test environment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "acvm-simulator"
+name = "acvm-js"
 version = "0.0.0"
 dependencies = [
  "acvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "acvm-simulator"
+name = "acvm-js"
 description = "Typescript wrapper around the ACVM allowing execution of ACIR code"
 version = "0.0.0" # x-release-please-version
 authors = ["The Noir Team <team@noir-lang.org>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/noir-lang/acvm-simulator"
+repository = "https://github.com/noir-lang/acvm-js"
 edition = "2021"
 rust-version = "1.66"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ACVM-js
+# acvm-js
 
-The ACVM-js enables users to execute an ACIR program, i.e. generating an initial witness from a set of inputs and calculating a partial witness. This partial witness can then be used to create a proof of execution using an ACVM backend.
+The `acvm-js` package enables users to execute an ACIR program, i.e. generating an initial witness from a set of inputs and calculating a partial witness. This partial witness can then be used to create a proof of execution using an ACVM backend.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ACVM Simulator
+# ACVM-js
 
-The ACVM Simulator enables users to execute an ACIR program, i.e. generating an initial witness from a set of inputs and calculating a partial witness. This partial witness can then be used to create a proof of execution using an ACVM backend.
+The ACVM-js enables users to execute an ACIR program, i.e. generating an initial witness from a set of inputs and calculating a partial witness. This partial witness can then be used to create a proof of execution using an ACVM backend.
 
 ## Dependencies
 

--- a/buildPhaseCargoCommand.sh
+++ b/buildPhaseCargoCommand.sh
@@ -5,9 +5,9 @@ if [ -d ./pkg/ ]; then
     rm -rf ./pkg/
 fi
 
-WASM_BINARY=./target/wasm32-unknown-unknown/release/acvm_simulator.wasm
-NODE_WASM=./pkg/nodejs/acvm_simulator_bg.wasm
-BROWSER_WASM=./pkg/nodejs/acvm_simulator_bg.wasm
+WASM_BINARY=./target/wasm32-unknown-unknown/release/acvm_js.wasm
+NODE_WASM=./pkg/nodejs/acvm_js_bg.wasm
+BROWSER_WASM=./pkg/nodejs/acvm_js_bg.wasm
 
 # Build the new wasm package
 cargo build --lib --release --target wasm32-unknown-unknown

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "ACVM Simulator";
+  description = "Javascript bindings for the ACVM";
 
   inputs = {
     nixpkgs = {
@@ -95,7 +95,7 @@
       GIT_DIRTY = if (self ? rev) then "false" else "true";
 
       commonArgs = {
-        pname = "acvm-simulator";
+        pname = "acvm-js";
         version = "0.0.0"; # x-release-please-version
 
         src = pkgs.lib.cleanSourceWith {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "acvm-simulator",
+  "name": "acvm-js",
   "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/noir-lang/acvm-simulator.git"
+    "url": "https://github.com/noir-lang/acvm-js.git"
   },
   "collaborators": [
     "The Noir Team <team@noir-lang.org>"
   ],
   "license": "MIT",
-  "main": "./nodejs/acvm_simulator.js",
-  "types": "./web/acvm_simulator.d.ts",
-  "module": "./web/acvm_simulator.js",
+  "main": "./nodejs/acvm_js.js",
+  "types": "./web/acvm_js.d.ts",
+  "module": "./web/acvm_js.js",
   "files": [
     "nodejs",
     "web",

--- a/src/barretenberg/mod.rs
+++ b/src/barretenberg/mod.rs
@@ -1,4 +1,4 @@
-//! ACVM simulator is independent of the proving backend against which the ACIR code is being proven.
+//! ACVM execution is independent of the proving backend against which the ACIR code is being proven.
 //! However there are currently a few opcodes for which there is currently no rust implementation so we must
 //! use the C++ implementations included in Aztec Lab's Barretenberg library.
 //!

--- a/test/browser/abi_encode.test.ts
+++ b/test/browser/abi_encode.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@esm-bundle/chai";
-import initACVMSimulator, {
+import initACVM, {
   abiEncode,
   abiDecode,
   WitnessMap,
@@ -7,7 +7,7 @@ import initACVMSimulator, {
 import { DecodedInputs } from "../types";
 
 beforeEach(async () => {
-  await initACVMSimulator();
+  await initACVM();
 });
 
 it("recovers original inputs when abi encoding and decoding", async () => {

--- a/test/browser/abi_encode.test.ts
+++ b/test/browser/abi_encode.test.ts
@@ -1,9 +1,5 @@
 import { expect } from "@esm-bundle/chai";
-import initACVM, {
-  abiEncode,
-  abiDecode,
-  WitnessMap,
-} from "../../result/";
+import initACVM, { abiEncode, abiDecode, WitnessMap } from "../../result/";
 import { DecodedInputs } from "../types";
 
 beforeEach(async () => {

--- a/test/browser/execute_circuit.test.ts
+++ b/test/browser/execute_circuit.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@esm-bundle/chai";
-import initACVMSimulator, {
+import initACVM, {
   abiEncode,
   abiDecode,
   executeCircuit,
@@ -8,7 +8,7 @@ import initACVMSimulator, {
 } from "../../result/";
 
 beforeEach(async () => {
-  await initACVMSimulator();
+  await initACVM();
 
   initLogLevel("INFO");
 });

--- a/test/browser/witness_conversion.test.ts
+++ b/test/browser/witness_conversion.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@esm-bundle/chai";
-import initACVMSimulator, {
+import initACVM, {
   compressWitness,
   decompressWitness,
 } from "../../result/";
@@ -9,7 +9,7 @@ import {
 } from "../shared/witness_compression";
 
 beforeEach(async () => {
-  await initACVMSimulator();
+  await initACVM();
 });
 
 it("successfully compresses the witness", async () => {

--- a/test/browser/witness_conversion.test.ts
+++ b/test/browser/witness_conversion.test.ts
@@ -1,8 +1,5 @@
 import { expect } from "@esm-bundle/chai";
-import initACVM, {
-  compressWitness,
-  decompressWitness,
-} from "../../result/";
+import initACVM, { compressWitness, decompressWitness } from "../../result/";
 import {
   expectedCompressedWitnessMap,
   expectedWitnessMap,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,9 +1258,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acvm-simulator@workspace:.":
+"acvm-js@workspace:.":
   version: 0.0.0-use.local
-  resolution: "acvm-simulator@workspace:."
+  resolution: "acvm-js@workspace:."
   dependencies:
     "@esm-bundle/chai": ^4.3.4-fix.0
     "@typescript-eslint/eslint-plugin": ^5.59.5


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #54 

## Summary\*

This PR renames `acvm-simulator` to `acvm-js`

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
