### PR TITLE
chore: document remaining functions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -10,6 +10,7 @@
         "jsdoc",
         "keccak",
         "merkle",
+        "nargo",
         "pedersen",
         "prehashed",
         "pubkey",

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -4,7 +4,11 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::JsWitnessMap;
 
-#[wasm_bindgen(js_name = compressWitness)]
+/// Compresses a `WitnessMap` into the binary format outputted by Nargo.
+///
+/// @param {Uint8Array} compressed_witness - A witness map.
+/// @returns {WitnessMap} A compressed witness map
+#[wasm_bindgen(js_name = compressWitness, skip_jsdoc)]
 pub fn compress_witness(witness_map: JsWitnessMap) -> Result<Vec<u8>, JsString> {
     console_error_panic_hook::set_once();
 
@@ -15,7 +19,11 @@ pub fn compress_witness(witness_map: JsWitnessMap) -> Result<Vec<u8>, JsString> 
     Ok(compressed_witness_map)
 }
 
-#[wasm_bindgen(js_name = decompressWitness)]
+/// Decompresses a compressed witness as outputted by Nargo into a `WitnessMap`.
+///
+/// @param {Uint8Array} compressed_witness - A compressed witness.
+/// @returns {WitnessMap} The decompressed witness map.
+#[wasm_bindgen(js_name = decompressWitness, skip_jsdoc)]
 pub fn decompress_witness(compressed_witness: Vec<u8>) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,7 +14,10 @@ extern "C" {
     pub type LogLevel;
 }
 
-#[wasm_bindgen(js_name = initLogLevel)]
+/// Sets the package's logging level.
+///
+/// @param {LogLevel} level - The maximum level of logging to be emitted.
+#[wasm_bindgen(js_name = initLogLevel, skip_jsdoc)]
 pub fn init_log_level(level: LogLevel) {
     // Set the static variable from Rust
     use std::sync::Once;

--- a/src/public_witness.rs
+++ b/src/public_witness.rs
@@ -19,14 +19,19 @@ fn extract_indices(witness_map: &WitnessMap, indices: Vec<Witness>) -> Result<Wi
     Ok(extracted_witness_map)
 }
 
+/// Extracts a `WitnessMap` containing the witness indices corresponding to the circuit's return values.
+///
+/// @param {Uint8Array} circuit - A serialized representation of an ACIR circuit
+/// @param {WitnessMap} witness_map - The completed witness map after executing the circuit.
+/// @returns {WitnessMap} A witness map containing the circuit's return values.
 #[wasm_bindgen(js_name = getReturnWitness)]
 pub fn get_return_witness(
     circuit: Vec<u8>,
-    solved_witness: JsWitnessMap,
+    witness_map: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
     let circuit: Circuit = Circuit::read(&*circuit).expect("Failed to deserialize circuit");
-    let witness_map = WitnessMap::from(solved_witness);
+    let witness_map = WitnessMap::from(witness_map);
 
     let return_witness =
         extract_indices(&witness_map, circuit.return_values.0.into_iter().collect())?;
@@ -34,6 +39,11 @@ pub fn get_return_witness(
     Ok(JsWitnessMap::from(return_witness))
 }
 
+/// Extracts a `WitnessMap` containing the witness indices corresponding to the circuit's public parameters.
+///
+/// @param {Uint8Array} circuit - A serialized representation of an ACIR circuit
+/// @param {WitnessMap} witness_map - The completed witness map after executing the circuit.
+/// @returns {WitnessMap} A witness map containing the circuit's public parameters.
 #[wasm_bindgen(js_name = getPublicParametersWitness)]
 pub fn get_public_parameters_witness(
     circuit: Vec<u8>,
@@ -49,6 +59,11 @@ pub fn get_public_parameters_witness(
     Ok(JsWitnessMap::from(public_params_witness))
 }
 
+/// Extracts a `WitnessMap` containing the witness indices corresponding to the circuit's public inputs.
+///
+/// @param {Uint8Array} circuit - A serialized representation of an ACIR circuit
+/// @param {WitnessMap} witness_map - The completed witness map after executing the circuit.
+/// @returns {WitnessMap} A witness map containing the circuit's public inputs.
 #[wasm_bindgen(js_name = getPublicWitness)]
 pub fn get_public_witness(
     circuit: Vec<u8>,


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves #14 

## Summary\*

This PR adds jsdoc for all functions except the ABI encoding ones as they're being removed in #4 

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
